### PR TITLE
QOT-34: Added logic to close top renderer when empty

### DIFF
--- a/src/engine/terminal/window/ETerminal.java
+++ b/src/engine/terminal/window/ETerminal.java
@@ -408,7 +408,6 @@ public class ETerminal<E> extends WindowParent<E> implements EnvisionConsoleRece
 	@Override
 	public void close() {
 		super.close();
-		//if (isChat) { EnhancedMC.getEMCApp().unregisterChatTerminal(this); }
 	}
 	
 	//-----------------

--- a/src/engine/windowLib/windowTypes/WindowParent.java
+++ b/src/engine/windowLib/windowTypes/WindowParent.java
@@ -132,7 +132,20 @@ public class WindowParent<E> extends WindowObject<E> implements IWindowParent<E>
 	
 	@Override
 	public void close() {
-		if (getTopParent() == QoT.getTopRenderer()) TaskBar.windowClosed(this);
+		if (getTopParent() == QoT.getTopRenderer()) {
+			//update the taskbar
+			TaskBar.windowClosed(this);
+			
+			//get all active windows on the top renderer
+			var windows = QoT.getTopRenderer().getAllActiveWindows();
+			
+			//check if this is the only window on the top renderer
+			//if so, close the top renderer when closing the window
+			if (windows.size() == 1 && windows.getFirst() == this) {
+				QoT.getTopRenderer().setFocused(false);
+			}
+		}
+		
 		super.close();
 	}
 	


### PR DESCRIPTION
Upon closing windows in the top renderer, a check is now made to determine if it is the last window on the screen. If so, close the top renderer too.